### PR TITLE
Feature/task per user report

### DIFF
--- a/Reporting.Api/Controllers/ReportsController.cs
+++ b/Reporting.Api/Controllers/ReportsController.cs
@@ -15,9 +15,9 @@ public sealed class ReportsController : ControllerBase
     }
 
     [HttpGet("tasks-per-user")]
-    [ProducesResponseType(typeof(List<TasksPerUserReportDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(List<TasksPerUserRequestDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<List<TasksPerUserReportDto>>> GetTasksPerUserAsync(
+    public async Task<ActionResult<List<TasksPerUserRequestDto>>> GetTasksPerUserAsync(
     [FromQuery] bool useRawSql = false,
     [FromQuery] string? status = null,
     [FromQuery] DateTime? from = null,

--- a/Reporting.Api/Controllers/ReportsController.cs
+++ b/Reporting.Api/Controllers/ReportsController.cs
@@ -5,41 +5,28 @@ using Reporting.Application.Interfaces;
 namespace Reporting.Api.Controllers;
 
 [ApiController]
-[Route("api/reports")]
-public sealed class ReportsController : ControllerBase
+[Route("api/v1/reports")]
+public class ReportsController : ControllerBase
 {
     private readonly IReportService _reportService;
+
     public ReportsController(IReportService reportService)
     {
         _reportService = reportService;
     }
 
+    /// <summary>
+    /// Returns number of tasks per user
+    /// </summary>
     [HttpGet("tasks-per-user")]
-    [ProducesResponseType(typeof(List<TasksPerUserRequestDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult<List<TasksPerUserRequestDto>>> GetTasksPerUserAsync(
-    [FromQuery] bool useRawSql = false,
-    [FromQuery] string? status = null,
-    [FromQuery] DateTime? from = null,
-    [FromQuery] DateTime? to = null)
+    public async Task<IActionResult> GetTasksPerUser(
+        [FromQuery] TasksPerUserQuery query)
     {
-        if (from is not null && to is not null && from > to)
-        {
-            return BadRequest(new ProblemDetails
-            {
-                Title = "Invalid date range",
-                Detail = "'from' must be less than or equal to 'to'.",
-                Status = StatusCodes.Status400BadRequest
-            });
-        }
+        var result = await _reportService.GetTasksPerUserAsync(query);
 
-        var result = await _reportService.GetTasksPerUserAsync(
-            useRawSql,
-            status,
-            from,
-            to);
+        if (result.Count == 0)
+            return NoContent();
 
         return Ok(result);
     }
-
 }

--- a/Reporting.Api/Controllers/ReportsController.cs
+++ b/Reporting.Api/Controllers/ReportsController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Reporting.Application.DTOs;
+using Reporting.Application.Interfaces;
+
+namespace Reporting.Api.Controllers;
+
+[ApiController]
+[Route("api/reports")]
+public sealed class ReportsController : ControllerBase
+{
+    private readonly IReportService _reportService;
+    public ReportsController(IReportService reportService)
+    {
+        _reportService = reportService;
+    }
+
+    [HttpGet("tasks-per-user")]
+    [ProducesResponseType(typeof(List<TasksPerUserReportDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<List<TasksPerUserReportDto>>> GetTasksPerUserAsync(
+    [FromQuery] bool useRawSql = false,
+    [FromQuery] string? status = null,
+    [FromQuery] DateTime? from = null,
+    [FromQuery] DateTime? to = null)
+    {
+        if (from is not null && to is not null && from > to)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid date range",
+                Detail = "'from' must be less than or equal to 'to'.",
+                Status = StatusCodes.Status400BadRequest
+            });
+        }
+
+        var result = await _reportService.GetTasksPerUserAsync(
+            useRawSql,
+            status,
+            from,
+            to);
+
+        return Ok(result);
+    }
+
+}

--- a/Reporting.Api/Program.cs
+++ b/Reporting.Api/Program.cs
@@ -1,11 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Reporting.Infrastructure.Db;
+using Reporting.Application.Interfaces;
+using Reporting.Application.Services;
+using Reporting.Infrastructure.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
-
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-// builder.Services.AddOpenApi();
 
 // Controllers
 builder.Services.AddControllers();
@@ -16,18 +15,22 @@ builder.Services.AddDbContext<ReportingDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("Default"));
 });
 
+// Application Services
+builder.Services.AddScoped<
+    ITasksPerUserReportRepository,
+    TasksPerUserReportRepository>();
+
+builder.Services.AddScoped<IReportService, ReportService>();
 // Swagger
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-    // app.MapOpenApi();
 }
 
 app.UseHttpsRedirection();
@@ -38,10 +41,8 @@ app.MapControllers();
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ReportingDbContext>();
-    db.Database.Migrate(); // Apply migrations before Seed
-    SeedData.Initialize(db); // Seed the database
+    db.Database.Migrate();
+    SeedData.Initialize(db);
 }
 
 app.Run();
-
-

--- a/Reporting.Api/appsettings.json
+++ b/Reporting.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "Default": "Server=MINA\\MINAGD ;Database=ReportingDb;Trusted_Connection=True;TrustServerCertificate=True"
+    "Default": "Server=.;Database=ReportingDb;Trusted_Connection=True;TrustServerCertificate=True"
   },
   "Logging": {
     "LogLevel": {

--- a/Reporting.Application/DTOs/TasksPerUserQuery.cs
+++ b/Reporting.Application/DTOs/TasksPerUserQuery.cs
@@ -1,0 +1,8 @@
+﻿namespace Reporting.Application.DTOs;
+
+public record TasksPerUserQuery(
+    string? Status,
+    DateTime? From,
+    DateTime? To,
+    bool UseRawSql = false
+);

--- a/Reporting.Application/DTOs/TasksPerUserReportDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserReportDto.cs
@@ -1,5 +1,5 @@
 namespace Reporting.Application.DTOs;
-public class TasksPerUserRequestDto 
+public class TasksPerUserReportDto 
 {
     public int UserId { get; set; }
     public string? UserName { get; set; }

--- a/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
@@ -1,5 +1,5 @@
 namespace Reporting.Application.DTOs;
-public class TasksPerUserReportDto
+public class TasksPerUserRequestDto
 {
     public int UserId { get; set; }
     public string? UserName { get; set; }

--- a/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
@@ -1,5 +1,5 @@
 namespace Reporting.Application.DTOs;
-public class TasksPerUserRequestDto
+public class TasksPerUserRequestDto 
 {
     public int UserId { get; set; }
     public string? UserName { get; set; }

--- a/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
@@ -1,0 +1,8 @@
+namespace Reporting.Application.DTOs;
+public class TasksPerUserReportDto
+{
+    public Guid UserId { get; set; }
+    public string? UserName { get; set; }
+    public int TasksCount { get; set; }
+    //public string? TeamName { get; set; }
+}

--- a/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
@@ -1,7 +1,7 @@
 namespace Reporting.Application.DTOs;
 public class TasksPerUserReportDto
 {
-    public Guid UserId { get; set; }
+    public int UserId { get; set; }
     public string? UserName { get; set; }
     public int TasksCount { get; set; }
     //public string? TeamName { get; set; }

--- a/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserRequestDto.cs
@@ -4,5 +4,4 @@ public class TasksPerUserRequestDto
     public int UserId { get; set; }
     public string? UserName { get; set; }
     public int TasksCount { get; set; }
-    //public string? TeamName { get; set; }
 }

--- a/Reporting.Application/Interfaces/IReportService.cs
+++ b/Reporting.Application/Interfaces/IReportService.cs
@@ -1,1 +1,6 @@
+namespace Reporting.Application.Interfaces;
 
+public interface IReportService
+{
+
+}

--- a/Reporting.Application/Interfaces/IReportService.cs
+++ b/Reporting.Application/Interfaces/IReportService.cs
@@ -1,11 +1,10 @@
 using Reporting.Application.DTOs;
+
 namespace Reporting.Application.Interfaces;
 
 public interface IReportService
 {
-    Task<List<TasksPerUserRequestDto>> GetTasksPerUserAsync(
-        bool useRawSql = false,
-        string? status = null,
-        DateTime? from = null,
-        DateTime? to = null);
+    Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
+        TasksPerUserQuery query);
 }
+

--- a/Reporting.Application/Interfaces/IReportService.cs
+++ b/Reporting.Application/Interfaces/IReportService.cs
@@ -3,7 +3,7 @@ namespace Reporting.Application.Interfaces;
 
 public interface IReportService
 {
-    Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
+    Task<List<TasksPerUserRequestDto>> GetTasksPerUserAsync(
         bool useRawSql = false,
         string? status = null,
         DateTime? from = null,

--- a/Reporting.Application/Interfaces/IReportService.cs
+++ b/Reporting.Application/Interfaces/IReportService.cs
@@ -1,6 +1,11 @@
+using Reporting.Application.DTOs;
 namespace Reporting.Application.Interfaces;
 
 public interface IReportService
 {
-
+    Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
+        bool useRawSql = false,
+        string? status = null,
+        DateTime? from = null,
+        DateTime? to = null);
 }

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -4,12 +4,12 @@ namespace Reporting.Application.Interfaces;
 
 public interface ITasksPerUserReportRepository
 {
-    Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
+    Task<List<TasksPerUserRequestDto>> GetTasksPerUser_LinqAsync(
         string? status = null,
         DateTime? from = null,
         DateTime? to = null);
 
-    Task<List<TasksPerUserReportDto>> GetTasksPerUser_RawSqlAsync(
+    Task<List<TasksPerUserRequestDto>> GetTasksPerUser_RawSqlAsync(
         string? status = null,
         DateTime? from = null,
         DateTime? to = null);

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -1,1 +1,16 @@
+using Reporting.Application.DTOs;
 
+namespace Reporting.Application.Interfaces;
+
+public interface ITasksPerUserReportRepository
+{
+    Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
+        string? status = null,
+        DateTime? from = null,
+        DateTime? to = null);
+
+    Task<List<TasksPerUserReportDto>> GetTasksPerUser_RawSqlAsync(
+        string? status = null,
+        DateTime? from = null,
+        DateTime? to = null);
+}

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -4,12 +4,12 @@ namespace Reporting.Application.Interfaces;
 
 public interface ITasksPerUserReportRepository
 {
-    Task<List<TasksPerUserRequestDto>> GetTasksPerUser_LinqAsync(
+    Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
         string? status = null,
         DateTime? from = null,
         DateTime? to = null);
 
-    Task<List<TasksPerUserRequestDto>> GetTasksPerUser_RawSqlAsync(
+    Task<List<TasksPerUserReportDto>> GetTasksPerUser_RawSqlAsync(
         string? status = null,
         DateTime? from = null,
         DateTime? to = null);

--- a/Reporting.Application/Services/ReportService.cs
+++ b/Reporting.Application/Services/ReportService.cs
@@ -12,15 +12,20 @@ public class ReportService : IReportService
         _repository = repository;
     }
 
-    public async Task<List<TasksPerUserRequestDto>> GetTasksPerUserAsync(
-        bool useRawSql = false,
-        string? status = null,
-        DateTime? from = null,
-        DateTime? to = null)
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
+        TasksPerUserQuery query)
     {
-        if (useRawSql)
-            return await _repository.GetTasksPerUser_RawSqlAsync(status, from, to);
+        if (query.From.HasValue && query.To.HasValue &&
+            query.From > query.To)
+        {
+            throw new ArgumentException("From date cannot be greater than To date");
+        }
 
-        return await _repository.GetTasksPerUser_LinqAsync(status, from, to);
+        return query.UseRawSql
+            ? await _repository.GetTasksPerUser_RawSqlAsync(
+                query.Status, query.From, query.To)
+            : await _repository.GetTasksPerUser_LinqAsync(
+                query.Status, query.From, query.To);
     }
 }
+

--- a/Reporting.Application/Services/ReportService.cs
+++ b/Reporting.Application/Services/ReportService.cs
@@ -2,6 +2,7 @@ using Reporting.Application.DTOs;
 using Reporting.Application.Interfaces;
 
 namespace Reporting.Application.Services;
+
 public class ReportService : IReportService
 {
     private readonly ITasksPerUserReportRepository _repository;
@@ -11,7 +12,11 @@ public class ReportService : IReportService
         _repository = repository;
     }
 
-    public async Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(bool useRawSql = false, string? status = null, DateTime? from = null, DateTime? to = null)
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
+        bool useRawSql = false,
+        string? status = null,
+        DateTime? from = null,
+        DateTime? to = null)
     {
         if (useRawSql)
             return await _repository.GetTasksPerUser_RawSqlAsync(status, from, to);

--- a/Reporting.Application/Services/ReportService.cs
+++ b/Reporting.Application/Services/ReportService.cs
@@ -12,7 +12,7 @@ public class ReportService : IReportService
         _repository = repository;
     }
 
-    public async Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
+    public async Task<List<TasksPerUserRequestDto>> GetTasksPerUserAsync(
         bool useRawSql = false,
         string? status = null,
         DateTime? from = null,

--- a/Reporting.Application/Services/ReportService.cs
+++ b/Reporting.Application/Services/ReportService.cs
@@ -1,0 +1,21 @@
+using Reporting.Application.DTOs;
+using Reporting.Application.Interfaces;
+
+namespace Reporting.Application.Services;
+public class ReportService : IReportService
+{
+    private readonly ITasksPerUserReportRepository _repository;
+
+    public ReportService(ITasksPerUserReportRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(bool useRawSql = false, string? status = null, DateTime? from = null, DateTime? to = null)
+    {
+        if (useRawSql)
+            return await _repository.GetTasksPerUser_RawSqlAsync(status, from, to);
+
+        return await _repository.GetTasksPerUser_LinqAsync(status, from, to);
+    }
+}

--- a/Reporting.Infrastructure/Db/ReportingDbContext.cs
+++ b/Reporting.Infrastructure/Db/ReportingDbContext.cs
@@ -76,7 +76,7 @@ public sealed class ReportingDbContext : DbContext
             .HasIndex(t => t.CompletedAt);
 
         // Reporting DTO
-        modelBuilder.Entity<TasksPerUserReportDto>(eb =>
+        modelBuilder.Entity<TasksPerUserRequestDto>(eb =>
         {
             eb.HasNoKey();
             eb.ToView(null); // no db object

--- a/Reporting.Infrastructure/Db/ReportingDbContext.cs
+++ b/Reporting.Infrastructure/Db/ReportingDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Reporting.Application.DTOs;
 using Reporting.Domain.Entities;
 
 namespace Reporting.Infrastructure.Db;
@@ -36,7 +37,7 @@ public sealed class ReportingDbContext : DbContext
         modelBuilder.Entity<Project>()
                 .HasKey(p => p.Id);
 
-         // Task
+        // Task
         modelBuilder.Entity<TaskEntity>()
                 .HasKey(t => t.Id);
 
@@ -73,5 +74,13 @@ public sealed class ReportingDbContext : DbContext
 
         modelBuilder.Entity<TaskEntity>()
             .HasIndex(t => t.CompletedAt);
+
+        // Reporting DTO
+        modelBuilder.Entity<TasksPerUserReportDto>(eb =>
+        {
+            eb.HasNoKey();
+            eb.ToView(null); // no db object
+        });
+
     }
 }

--- a/Reporting.Infrastructure/Db/ReportingDbContext.cs
+++ b/Reporting.Infrastructure/Db/ReportingDbContext.cs
@@ -76,7 +76,7 @@ public sealed class ReportingDbContext : DbContext
             .HasIndex(t => t.CompletedAt);
 
         // Reporting DTO
-        modelBuilder.Entity<TasksPerUserRequestDto>(eb =>
+        modelBuilder.Entity<TasksPerUserReportDto>(eb =>
         {
             eb.HasNoKey();
             eb.ToView(null); // no db object

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Reporting.Application.DTOs;
 using Reporting.Infrastructure.Db;
@@ -25,22 +26,66 @@ public sealed class TasksPerUserReportRepository
         if(!string.IsNullOrWhiteSpace(status))
             tasks = tasks.Where(t => t.Status == status);
 
-        if (to.HasValue)
+        if (from.HasValue)
             tasks = tasks.Where(t => t.CreatedAt >= from.Value);
 
-        if (from.HasValue)
+        if (to.HasValue)
             tasks = tasks.Where(t => t.CreatedAt <= to.Value);
 
         return await tasks
-            .GroupBy(t => t.UserId)
+            .GroupBy(t => new { t.UserId, t.User.Name })
             .Select(g => new TasksPerUserReportDto
             {
-                UserId = g.Key,
-                UserName = g.Select(x => x.User.Name).FirstOrDefault(),
+                UserId = ()g.Key.UserId,
+                UserName = g.Key.Name,
                 TasksCount = g.Count()
             })
             .OrderByDescending(x => x.TasksCount)
             .ToListAsync();
 
     }
+
+    public async Task<List<TasksPerUserReportDto>> GetTaskPerUser_RawSqlAsync(
+    string? status = null,
+    DateTime? from = null,
+    DateTime? to = null)
+    {
+        var sql = @"
+        SELECT 
+            u.Id AS UserId,
+            u.Name AS UserName,
+            COUNT(t.Id) AS TasksCount
+        FROM Tasks t
+        JOIN Users u ON t.UserId = u.Id
+        WHERE 1 = 1
+    ";
+
+        var parameters = new List<SqlParameter>();
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            sql += " AND t.Status = @status";
+            parameters.Add(new SqlParameter("@status", status));
+        }
+
+        if (from.HasValue)
+        {
+            sql += " AND t.CreatedAt >= @from";
+            parameters.Add(new SqlParameter("@from", from.Value));
+        }
+
+        if (to.HasValue)
+        {
+            sql += " AND t.CreatedAt <= @to";
+            parameters.Add(new SqlParameter("@to", to.Value));
+        }
+
+        sql += " GROUP BY u.Id, u.Name ORDER BY TasksCount DESC";
+
+        return await _context.Set<TasksPerUserReportDto>()
+            .FromSqlRaw(sql, parameters.ToArray())
+            .AsNoTracking()
+            .ToListAsync();
+    }
+
 }

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -36,7 +36,7 @@ public sealed class TasksPerUserReportRepository
             .GroupBy(t => new { t.UserId, t.User.Name })
             .Select(g => new TasksPerUserReportDto
             {
-                UserId = ()g.Key.UserId,
+                UserId = g.Key.UserId,
                 UserName = g.Key.Name,
                 TasksCount = g.Count()
             })

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Reporting.Application.DTOs;
+using Reporting.Infrastructure.Db;
+
+namespace Reporting.Infrastructure.Repositories;
+
+public sealed class TasksPerUserReportRepository
+{
+    private readonly ReportingDbContext _context;
+
+    public TasksPerUserReportRepository(ReportingDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
+        string? status = null,
+        DateTime? from = null,
+        DateTime? to = null)
+    {
+        var tasks = _context.Tasks
+            .AsNoTracking()
+            .AsQueryable();
+
+        if(!string.IsNullOrWhiteSpace(status))
+            tasks = tasks.Where(t => t.Status == status);
+
+        if (to.HasValue)
+            tasks = tasks.Where(t => t.CreatedAt >= from.Value);
+
+        if (from.HasValue)
+            tasks = tasks.Where(t => t.CreatedAt <= to.Value);
+
+        return await tasks
+            .GroupBy(t => t.UserId)
+            .Select(g => new TasksPerUserReportDto
+            {
+                UserId = g.Key,
+                UserName = g.Select(x => x.User.Name).FirstOrDefault(),
+                TasksCount = g.Count()
+            })
+            .OrderByDescending(x => x.TasksCount)
+            .ToListAsync();
+
+    }
+}

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -45,7 +45,7 @@ public sealed class TasksPerUserReportRepository
 
     }
 
-    public async Task<List<TasksPerUserRequestDto>> GetTaskPerUser_RawSqlAsync(
+    public async Task<List<TasksPerUserRequestDto>> GetTasksPerUser_RawSqlAsync(
     string? status = null,
     DateTime? from = null,
     DateTime? to = null)

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -16,16 +16,14 @@ public sealed class TasksPerUserReportRepository
         _context = context;
     }
 
-    public async Task<List<TasksPerUserRequestDto>> GetTasksPerUser_LinqAsync(
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
         string? status = null,
         DateTime? from = null,
         DateTime? to = null)
     {
-        var tasks = _context.Tasks
-            .AsNoTracking()
-            .AsQueryable();
+        var tasks = _context.Tasks.AsNoTracking().AsQueryable();
 
-        if(!string.IsNullOrWhiteSpace(status))
+        if (!string.IsNullOrWhiteSpace(status))
             tasks = tasks.Where(t => t.Status == status);
 
         if (from.HasValue)
@@ -36,7 +34,7 @@ public sealed class TasksPerUserReportRepository
 
         return await tasks
             .GroupBy(t => new { t.UserId, t.User.Name })
-            .Select(g => new TasksPerUserRequestDto
+            .Select(g => new TasksPerUserReportDto
             {
                 UserId = g.Key.UserId,
                 UserName = g.Key.Name,
@@ -44,15 +42,14 @@ public sealed class TasksPerUserReportRepository
             })
             .OrderByDescending(x => x.TasksCount)
             .ToListAsync();
-
     }
 
-    public async Task<List<TasksPerUserRequestDto>> GetTasksPerUser_RawSqlAsync(
-    string? status = null,
-    DateTime? from = null,
-    DateTime? to = null)
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_RawSqlAsync(
+        string? status = null,
+        DateTime? from = null,
+        DateTime? to = null)
     {
-        var sql = @"
+        var sql = """
         SELECT 
             u.Id AS UserId,
             u.Name AS UserName,
@@ -60,7 +57,7 @@ public sealed class TasksPerUserReportRepository
         FROM Tasks t
         JOIN Users u ON t.UserId = u.Id
         WHERE 1 = 1
-    ";
+        """;
 
         var parameters = new List<SqlParameter>();
 
@@ -84,10 +81,9 @@ public sealed class TasksPerUserReportRepository
 
         sql += " GROUP BY u.Id, u.Name ORDER BY TasksCount DESC";
 
-        return await _context.Set<TasksPerUserRequestDto>()
+        return await _context.Set<TasksPerUserReportDto>()
             .FromSqlRaw(sql, parameters.ToArray())
             .AsNoTracking()
             .ToListAsync();
     }
-
 }

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -14,7 +14,7 @@ public sealed class TasksPerUserReportRepository
         _context = context;
     }
 
-    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
+    public async Task<List<TasksPerUserRequestDto>> GetTasksPerUser_LinqAsync(
         string? status = null,
         DateTime? from = null,
         DateTime? to = null)
@@ -34,7 +34,7 @@ public sealed class TasksPerUserReportRepository
 
         return await tasks
             .GroupBy(t => new { t.UserId, t.User.Name })
-            .Select(g => new TasksPerUserReportDto
+            .Select(g => new TasksPerUserRequestDto
             {
                 UserId = g.Key.UserId,
                 UserName = g.Key.Name,
@@ -45,7 +45,7 @@ public sealed class TasksPerUserReportRepository
 
     }
 
-    public async Task<List<TasksPerUserReportDto>> GetTaskPerUser_RawSqlAsync(
+    public async Task<List<TasksPerUserRequestDto>> GetTaskPerUser_RawSqlAsync(
     string? status = null,
     DateTime? from = null,
     DateTime? to = null)
@@ -82,7 +82,7 @@ public sealed class TasksPerUserReportRepository
 
         sql += " GROUP BY u.Id, u.Name ORDER BY TasksCount DESC";
 
-        return await _context.Set<TasksPerUserReportDto>()
+        return await _context.Set<TasksPerUserRequestDto>()
             .FromSqlRaw(sql, parameters.ToArray())
             .AsNoTracking()
             .ToListAsync();

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -1,11 +1,13 @@
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Reporting.Application.DTOs;
+using Reporting.Application.Interfaces;
 using Reporting.Infrastructure.Db;
 
 namespace Reporting.Infrastructure.Repositories;
 
 public sealed class TasksPerUserReportRepository
+    : ITasksPerUserReportRepository
 {
     private readonly ReportingDbContext _context;
 


### PR DESCRIPTION
### Summary
Add Tasks Per User report with both LINQ and Raw SQL implementations.

### Changes
- Add TasksPerUserReportDto
- Register DTO as keyless in ReportingDbContext
- Implement GetTasksPerUser_LinqAsync in ReportRepository
- Implement GetTasksPerUser_RawSqlAsync in ReportRepository
- Add GetTasksPerUserAsync in ReportService (switcher)
- Add API endpoint: GET /api/reports/tasks-per-user
- Add basic test scaffold

### Usage
- GET /api/reports/tasks-per-user?rawSql=false
- GET /api/reports/tasks-per-user?rawSql=true
Optional filters: `status`, `from`, `to`

### Checklist
- [ ] DTO added
- [ ] Repository methods implemented
- [ ] Service method added
- [ ] Controller endpoint added

Please review:
- SQL parameterization and safety
- Any missing index suggestions for performance
- Naming / folder placement
