### PR TITLE
Completed Tasks per Week

### DIFF
--- a/Reporting.Api/Controllers/ReportsController.cs
+++ b/Reporting.Api/Controllers/ReportsController.cs
@@ -29,4 +29,16 @@ public class ReportsController : ControllerBase
 
         return Ok(result);
     }
+
+    /// <summary>
+    /// Returns weekly report of completed tasks.
+    /// </summary>
+    [HttpGet("completed-tasks-per-week")]
+    public async Task<IActionResult> GetCompletedTasksPerWeek([FromQuery] CompletedTasksPerWeekQuery query)
+    {
+        var result = await _reportService
+            .GetCompletedTasksPerWeekAsync(query);
+
+        return Ok(result);
+    }
 }

--- a/Reporting.Application/DTOs/CompletedTasksPerWeekQuery.cs
+++ b/Reporting.Application/DTOs/CompletedTasksPerWeekQuery.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Reporting.Application.DTOs
+{
+    public class CompletedTasksPerWeekQuery
+    {
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+    }
+}

--- a/Reporting.Application/DTOs/CompletedTasksPerWeekReportDto.cs
+++ b/Reporting.Application/DTOs/CompletedTasksPerWeekReportDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Reporting.Application.DTOs
+{
+    public class CompletedTasksPerWeekReportDto
+    {
+        public int Year { get; set; }
+        public int WeekNumber { get; set; }
+        public int CompletedTasksCount { get; set; }
+    }
+}

--- a/Reporting.Application/Interfaces/IReportService.cs
+++ b/Reporting.Application/Interfaces/IReportService.cs
@@ -6,5 +6,9 @@ public interface IReportService
 {
     Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
         TasksPerUserQuery query);
+
+    //Calls repository to get weekly completed tasks report
+    Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(
+            CompletedTasksPerWeekQuery query);
 }
 

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -13,4 +13,7 @@ public interface ITasksPerUserReportRepository
         string? status = null,
         DateTime? from = null,
         DateTime? to = null);
+
+    Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(
+           CompletedTasksPerWeekQuery query);
 }

--- a/Reporting.Application/Services/ReportService.cs
+++ b/Reporting.Application/Services/ReportService.cs
@@ -1,5 +1,6 @@
 using Reporting.Application.DTOs;
 using Reporting.Application.Interfaces;
+using System.Threading.Tasks;
 
 namespace Reporting.Application.Services;
 
@@ -26,6 +27,14 @@ public class ReportService : IReportService
                 query.Status, query.From, query.To)
             : await _repository.GetTasksPerUser_LinqAsync(
                 query.Status, query.From, query.To);
+    }
+
+    //Calls repository to get weekly completed tasks report
+    public async Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(
+            CompletedTasksPerWeekQuery query)
+    {
+        return await _repository
+            .GetCompletedTasksPerWeekAsync(query);
     }
 }
 

--- a/Reporting.Infrastructure/Db/ReportingDbContext.cs
+++ b/Reporting.Infrastructure/Db/ReportingDbContext.cs
@@ -82,5 +82,7 @@ public sealed class ReportingDbContext : DbContext
             eb.ToView(null); // no db object
         });
 
+        // It doesn't represent a real table and has no primary key
+        modelBuilder.Entity<CompletedTasksPerWeekReportDto>().HasNoKey();
     }
 }

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -87,7 +87,7 @@ public sealed class TasksPerUserReportRepository
             .ToListAsync();
     }
 
-    public async Task<List<CompletedTasksPerWeekReportDto>> GetTasksPerUserAsync(CompletedTasksPerWeekQuery query)
+    public async Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(CompletedTasksPerWeekQuery query)
     {
         var sql = @"
             SELECT
@@ -119,5 +119,6 @@ public sealed class TasksPerUserReportRepository
             .FromSqlRaw(sql, parameters)
             .AsNoTracking()
             .ToListAsync();
+
     }
 }

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -86,4 +86,38 @@ public sealed class TasksPerUserReportRepository
             .AsNoTracking()
             .ToListAsync();
     }
+
+    public async Task<List<CompletedTasksPerWeekReportDto>> GetTasksPerUserAsync(CompletedTasksPerWeekQuery query)
+    {
+        var sql = @"
+            SELECT
+                DATEPART(YEAR, CompletedAt)      AS [Year],
+                DATEPART(WEEK, CompletedAt)      AS [WeekNumber],
+                COUNT(*)                         AS [CompletedTasksCount]
+            FROM Tasks
+            WHERE
+                CompletedAt IS NOT NULL
+                AND CompletedAt >= @StartDate
+                AND CompletedAt <= @EndDate
+            GROUP BY
+                DATEPART(YEAR, CompletedAt),
+                DATEPART(WEEK, CompletedAt)
+            ORDER BY
+                [Year],
+                [WeekNumber];
+
+            ";
+
+        var parameters = new[]
+        {
+    new SqlParameter("@StartDate", query.StartDate),
+    new SqlParameter("@EndDate", query.EndDate)
+};
+
+        return await _context
+            .Set<CompletedTasksPerWeekReportDto>()
+            .FromSqlRaw(sql, parameters)
+            .AsNoTracking()
+            .ToListAsync();
+    }
 }


### PR DESCRIPTION
This PR adds a new **weekly report for completed tasks**.
The report shows tasks completed each week in a chosen date range.
It is **read-only** and follows the same style as other reports in the project.

Changes made:
- Added DTOs for the weekly report
- Added repository method with raw SQL for weekly totals
- Set up the report DTO as a keyless entity in DbContext
- Added service method to provide the report
- Added API endpoint to get the weekly report

No current features are changed by this update.
