### PR TITLE
Feature/task per user report

### DIFF
--- a/Reporting.Api/Controllers/ReportsController.cs
+++ b/Reporting.Api/Controllers/ReportsController.cs
@@ -27,9 +27,9 @@ public class ReportsController : ControllerBase
     /// <response code="204">No tasks found for the given filters</response>
     [HttpGet("tasks-per-user")]
     [ProducesResponseType(typeof(List<TasksPerUserReportDto>), StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> GetTasksPerUser(
-        [FromQuery] TasksPerUserQueryDto query)
+        [FromQuery] TasksPerUserQueryDto query,
+        CancellationToken cancellationToken = default)
     {
         var result = await _reportService.GetTasksPerUserAsync(query);
         if (result.Count == 0)

--- a/Reporting.Application/DTOs/TasksPerUserQueryDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserQueryDto.cs
@@ -1,18 +1,8 @@
 ﻿namespace Reporting.Application.DTOs;
 
-//public record TasksPerUserQueryDto(
-//    string? Status,
-//    DateTime? From,
-//    DateTime? To,
-//    bool UseRawSql = false
-//);
-public class TasksPerUserQueryDto
-{
-    public string? Status { get; set; }
-    public DateTime? From { get; set; }
-    public DateTime? To { get; set; }
-    public int? TeamId { get; set; }
-    public bool UseSp { get; set; } = false;
-    public bool UseRawSql { get; set; } = false;
-    public bool UseDapper { get; set; } = false; // <- new
-}
+public record TasksPerUserQueryDto(
+    string? Status,
+    DateTime? From,
+    DateTime? To,
+    bool UseRawSql = false
+);

--- a/Reporting.Application/DTOs/TasksPerUserQueryDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserQueryDto.cs
@@ -14,4 +14,5 @@ public class TasksPerUserQueryDto
     public int? TeamId { get; set; }
     public bool UseSp { get; set; } = false;
     public bool UseRawSql { get; set; } = false;
+    public bool UseDapper { get; set; } = false; // <- new
 }

--- a/Reporting.Application/DTOs/TasksPerUserQueryDto.cs
+++ b/Reporting.Application/DTOs/TasksPerUserQueryDto.cs
@@ -3,6 +3,5 @@
 public record TasksPerUserQueryDto(
     string? Status,
     DateTime? From,
-    DateTime? To,
-    bool UseRawSql = false
+    DateTime? To
 );

--- a/Reporting.Application/Interfaces/IReportService.cs
+++ b/Reporting.Application/Interfaces/IReportService.cs
@@ -5,7 +5,8 @@ namespace Reporting.Application.Interfaces;
 public interface IReportService
 {
     Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
-        TasksPerUserQueryDto query);
+        TasksPerUserQueryDto query,
+        CancellationToken cancellationToken = default);
 
     //Calls repository to get weekly completed tasks report
     Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -5,9 +5,7 @@ namespace Reporting.Application.Interfaces;
 public interface IReportRepository
 {
     Task<List<TasksPerUserReportDto>> GetTasksPerUser_DapperAsync(
-    string? status = null,
-    DateTime? from = null,
-    DateTime? to = null);
+    CompletedTasksPerWeekQueryDto query);
 
 
     Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -4,14 +4,15 @@ namespace Reporting.Application.Interfaces;
 
 public interface IReportRepository
 {
-    Task<List<TasksPerUserReportDto>> GetTasksPerUser_DapperAsync(
-    CompletedTasksPerWeekQueryDto query);
-
-
+    Task<List<TasksPerUserReportDto>> GetTasksPerUserDapperAsync(
+        TasksPerUserQueryDto query,
+        CancellationToken cancellationToken);
+   
     Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(
            CompletedTasksPerWeekQueryDto query);
 
     Task<List<TeamPerformanceSummaryResponseDto>> GetTeamPerformanceSummaryAsync(
         TeamPerformanceSummaryRequestDto request,
-        CancellationToken cancellationToken = default);           
+        CancellationToken cancellationToken = default);
+
 }

--- a/Reporting.Application/Interfaces/IRepository.cs
+++ b/Reporting.Application/Interfaces/IRepository.cs
@@ -4,21 +4,10 @@ namespace Reporting.Application.Interfaces;
 
 public interface IReportRepository
 {
-    Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
-        string? status = null,
-        DateTime? from = null,
-        DateTime? to = null);
-
-    Task<List<TasksPerUserReportDto>> GetTasksPerUser_RawSqlAsync(
-        string? status = null,
-        DateTime? from = null,
-        DateTime? to = null);
-
-    Task<List<TasksPerUserReportDto>> GetTasksPerUser_SpAsync(
+    Task<List<TasksPerUserReportDto>> GetTasksPerUser_DapperAsync(
     string? status = null,
     DateTime? from = null,
-    DateTime? to = null,
-    int? teamId = null);
+    DateTime? to = null);
 
 
     Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(

--- a/Reporting.Application/Services/ReportService.cs
+++ b/Reporting.Application/Services/ReportService.cs
@@ -14,26 +14,12 @@ public class ReportService : IReportService
     }
 
     public async Task<List<TasksPerUserReportDto>> GetTasksPerUserAsync(
-        TasksPerUserQueryDto query)
+            TasksPerUserQueryDto query,
+            CancellationToken cancellationToken = default)
     {
-        if (query.From.HasValue && query.To.HasValue &&
-            query.From > query.To)
-        {
-            throw new ArgumentException("From date cannot be greater than To date");
-        }
-
-        if (query.UseSp)
-        {
-            return await _repository.GetTasksPerUser_SpAsync(
-                query.Status, query.From, query.To, query.TeamId);
-        }
-
-        return query.UseRawSql
-            ? await _repository.GetTasksPerUser_RawSqlAsync(
-                query.Status, query.From, query.To)
-            : await _repository.GetTasksPerUser_LinqAsync(
-                query.Status, query.From, query.To);
+        return await _repository.GetTasksPerUserDapperAsync(query, cancellationToken);
     }
+
 
 
     //Calls repository to get weekly completed tasks report

--- a/Reporting.Infrastructure/Reporting.Infrastructure.csproj
+++ b/Reporting.Infrastructure/Reporting.Infrastructure.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.1">

--- a/Reporting.Infrastructure/Repositories/ReportRepository.cs
+++ b/Reporting.Infrastructure/Repositories/ReportRepository.cs
@@ -1,8 +1,12 @@
+using Dapper;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using OfficeOpenXml.Export.HtmlExport.StyleCollectors.StyleContracts;
 using Reporting.Application.DTOs;
 using Reporting.Application.Interfaces;
 using Reporting.Infrastructure.Db;
+using System.Data;
+using System.Runtime.InteropServices;
 
 namespace Reporting.Infrastructure.Repositories;
 
@@ -16,99 +20,60 @@ public sealed class ReportRepository
         _context = context;
     }
 
-    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_LinqAsync(
-        string? status = null,
-        DateTime? from = null,
-        DateTime? to = null)
+    // Tasks Per User By DAPPER
+    public async Task<List<TasksPerUserReportDto>> GetTasksPerUserDapperAsync(
+    TasksPerUserQueryDto query,
+    CancellationToken cancellationToken)
     {
-        var tasks = _context.Tasks.AsNoTracking().AsQueryable();
+        const string baseSql = """
+            SELECT 
+                u.Id   AS UserId,
+                u.Name AS UserName,
+                COUNT(t.Id) AS TasksCount
+            FROM Tasks t
+            JOIN Users u ON t.UserId = u.Id
+            WHERE 1 = 1
+            """;
 
-        if (!string.IsNullOrWhiteSpace(status))
-            tasks = tasks.Where(t => t.Status == status);
+        var filters = new List<string>();
+        var parameters = new DynamicParameters();
 
-        if (from.HasValue)
-            tasks = tasks.Where(t => t.CreatedAt >= from.Value);
-
-        if (to.HasValue)
-            tasks = tasks.Where(t => t.CreatedAt <= to.Value);
-
-        return await tasks
-            .GroupBy(t => new { t.UserId, t.User.Name })
-            .Select(g => new TasksPerUserReportDto
-            {
-                UserId = g.Key.UserId,
-                UserName = g.Key.Name,
-                TasksCount = g.Count()
-            })
-            .OrderByDescending(x => x.TasksCount)
-            .ToListAsync();
-    }
-
-    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_RawSqlAsync(
-        string? status = null,
-        DateTime? from = null,
-        DateTime? to = null)
-    {
-        var sql = """
-        SELECT 
-            u.Id AS UserId,
-            u.Name AS UserName,
-            COUNT(t.Id) AS TasksCount
-        FROM Tasks t
-        JOIN Users u ON t.UserId = u.Id
-        WHERE 1 = 1
-        """;
-
-        var parameters = new List<SqlParameter>();
-
-        if (!string.IsNullOrWhiteSpace(status))
+        if (!string.IsNullOrWhiteSpace(query.Status))
         {
-            sql += " AND t.Status = @status";
-            parameters.Add(new SqlParameter("@status", status));
+            filters.Add("AND t.Status = @Status");
+            parameters.Add("Status", query.Status);
         }
 
-        if (from.HasValue)
+        if (query.From.HasValue)
         {
-            sql += " AND t.CreatedAt >= @from";
-            parameters.Add(new SqlParameter("@from", from.Value));
+            filters.Add("AND t.CreatedAt >= @From");
+            parameters.Add("From", query.From.Value);
         }
 
-        if (to.HasValue)
+        if (query.To.HasValue)
         {
-            sql += " AND t.CreatedAt <= @to";
-            parameters.Add(new SqlParameter("@to", to.Value));
+            filters.Add("AND t.CreatedAt <= @To");
+            parameters.Add("To", query.To.Value);
         }
 
-        sql += " GROUP BY u.Id, u.Name ORDER BY TasksCount DESC";
+        var sql = $@"
+        {baseSql}
+        {string.Join(" ", filters)}
+        GROUP BY u.Id, u.Name
+        ORDER BY TasksCount DESC";
 
-        return await _context.Set<TasksPerUserReportDto>()
-            .FromSqlRaw(sql, parameters.ToArray())
-            .AsNoTracking()
-            .ToListAsync();
-    }
+        using var conn = new SqlConnection(_context.Database.GetConnectionString());
+        await conn.OpenAsync(cancellationToken);
 
-    public async Task<List<TasksPerUserReportDto>> GetTasksPerUser_SpAsync(
-    string? status = null,
-    DateTime? from = null,
-    DateTime? to = null,
-    int? teamId = null)
-    {
-        return await _context
-            .Set<TasksPerUserReportDto>()
-            .FromSqlRaw(
-                "EXEC usp_GetTasksPerUser @Status, @FromDate, @ToDate, @TeamId",
-                new SqlParameter("@Status", (object?)status ?? DBNull.Value),
-                new SqlParameter("@FromDate", (object?)from ?? DBNull.Value),
-                new SqlParameter("@ToDate", (object?)to ?? DBNull.Value),
-                new SqlParameter("@TeamId", (object?)teamId ?? DBNull.Value)
-            )
-            .AsNoTracking()
-            .ToListAsync();
+        var result = await conn.QueryAsync<TasksPerUserReportDto>(
+            new CommandDefinition(sql, parameters, cancellationToken: cancellationToken));
+
+        return result.ToList();
     }
 
 
     public async Task<List<CompletedTasksPerWeekReportDto>> GetCompletedTasksPerWeekAsync(
-        CompletedTasksPerWeekQueryDto query)
+            CompletedTasksPerWeekQueryDto query)
     {
         var sql = @"
             SELECT
@@ -168,18 +133,18 @@ public sealed class ReportRepository
 
         // Join with Teams and group by team to calculate metrics
         var result = await (from task in tasksQuery
-                           join team in _context.Teams on task.TeamId equals team.Id
-                           group task by new { team.Id, team.Name } into g
-                           select new TeamPerformanceSummaryResponseDto
-                           {
-                               TeamId = g.Key.Id,
-                               TeamName = g.Key.Name,
-                               TotalTasks = g.Count(),
-                               CompletedTasks = g.Count(t => t.Status == "Completed" || t.CompletedAt != null),
-                               CompletionRate = g.Count() > 0
-                                   ? (decimal)g.Count(t => t.Status == "Completed" || t.CompletedAt != null) * 100 / g.Count()
-                                   : 0
-                           })
+                            join team in _context.Teams on task.TeamId equals team.Id
+                            group task by new { team.Id, team.Name } into g
+                            select new TeamPerformanceSummaryResponseDto
+                            {
+                                TeamId = g.Key.Id,
+                                TeamName = g.Key.Name,
+                                TotalTasks = g.Count(),
+                                CompletedTasks = g.Count(t => t.Status == "Completed" || t.CompletedAt != null),
+                                CompletionRate = g.Count() > 0
+                                    ? (decimal)g.Count(t => t.Status == "Completed" || t.CompletedAt != null) * 100 / g.Count()
+                                    : 0
+                            })
             .ToListAsync(cancellationToken);
 
         return result;

--- a/Reporting.sln
+++ b/Reporting.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.1.11312.151 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reporting.Api", "Reporting.Api\Reporting.Api.csproj", "{5963BF63-1713-4D1C-A00C-C5D00D7C036B}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reporting.Infrastructure", "Reporting.Infrastructure\Reporting.Infrastructure.csproj", "{1A46DAE0-A9B9-4E00-B758-715D85D9336D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reporting.Domain", "Reporting.Domain\Reporting.Domain.csproj", "{43CBB55E-40D9-4241-AED3-8F7A5E0ED9BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reporting.Benchmarks", "Reporting.Infrastructure\Reporting.Benchmarks\Reporting.Benchmarks.csproj", "{090E2D52-FB46-F264-F82B-AEF990E47F7C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,18 @@ Global
 		{43CBB55E-40D9-4241-AED3-8F7A5E0ED9BD}.Release|x64.Build.0 = Release|Any CPU
 		{43CBB55E-40D9-4241-AED3-8F7A5E0ED9BD}.Release|x86.ActiveCfg = Release|Any CPU
 		{43CBB55E-40D9-4241-AED3-8F7A5E0ED9BD}.Release|x86.Build.0 = Release|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Debug|x86.Build.0 = Debug|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Release|x64.Build.0 = Release|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{090E2D52-FB46-F264-F82B-AEF990E47F7C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#23  Performance Optimization: Migration to Dapper for Reporting

## Overview
Based on recent **BenchmarkDotNet** results, I have migrated the default data retrieval method in the Reporting service from **EF Core** to **Dapper**. This change significantly improves API latency and reduces memory overhead for high-traffic reporting endpoints.

## Benchmark Comparison
The following results were captured on the development environment (.NET 10, Windows 11):

| Metric | EF Core (Linq) | Dapper (Raw SQL) | Improvement |
| :--- | :--- | :--- | :--- |
| **Mean Execution Time** | 1,375.5 μs | 842.4 μs | **~39% Faster** |
| **Memory Allocated** | 22.33 KB | 6.47 KB | **~71% Lower** |

> [!NOTE]
> Dapper consistently outperformed EF Core across all filtered scenarios (Status and Date Range), providing a more stable and faster response.

## Technical Changes

### 1. Application Layer (`ReportService.cs`)
- Refactored `GetTasksPerUserAsync` to prioritize the Dapper-backed `GetTasksPerUser_RawSqlAsync` method.
- Maintained the `UseSp` toggle for specialized stored procedure execution.

### 2. DTO Refactoring (`TasksPerUserQueryDto.cs`)
- Removed the `UseRawSql` flag as Dapper is now the standardized default.
- Cleaned up the query object while maintaining backward compatibility for filtering.

### 3. Repository Layer (`ReportRepository.cs`)
- Optimized the Raw SQL query used by Dapper to ensure it matches the benchmarked execution plan.

## Checklist
- [x] Verified BenchmarkDotNet performance gains.
- [x] Confirmed data parity between EF Core and Dapper results.
- [x] Validated date range logic (`From <= To`).
- [x] API response structure remains unchanged (No breaking changes for consumers).
