### PR TITLE
Fix: ensure stored procedures are created at startup

### DIFF
--- a/Reporting.Infrastructure/Reporting.Infrastructure.csproj
+++ b/Reporting.Infrastructure/Reporting.Infrastructure.csproj
@@ -22,6 +22,16 @@
     <EmbeddedResource Remove="Reporting.Benchmarks\**\*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="Queries\GetCompletedTasksPerWeek.sql" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Queries\GetCompletedTasksPerWeek.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Automatically creates required stored procedures on startup to support clean database initialization without migrations.